### PR TITLE
Bumping the Spring Starter Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
   </parent>
 
   <!-- (2) <groupId/> -->
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-gateway-mvc</artifactId>
-      <version>4.1.3</version>
+      <version>4.2.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
In this PR, I bump the version of `spring-boot-starter-parent` from `3.4.2` to `3.4.3` and Update `spring-cloud-gateway-mvc` to match, as the `4.2` version support spring 3.4.*. This is to rectify that on localhost, 3.4.2 simply stays in a connecting state rather than proxying to the React Server when using the `FrontendProxyController` locally.