### PR TITLE
Fixing the Javadoc Workflows

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [initialize]
     env:
-      destination: target/site/apidocs   
+      destination: target/reports/apidocs   
     steps:
     - name: Checkout local code to establish repo
       uses: actions/checkout@v4
@@ -296,7 +296,7 @@ jobs:
     needs: [initialize]
 
     env:
-      destination: target/site/apidocs   
+      destination: target/reports/apidocs   
     strategy:
       matrix:
         value: ${{ fromJSON(needs.initialize.outputs.pull_requests)}}

--- a/.github/workflows/04-gh-pages-redeploy-part-2.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
-  javadoc_dest: target/site/apidocs
+  javadoc_dest: target/reports/apidocs
   chromatic_dest: frontend/chromatic_static
   jacoco_dest: target/site/jacoco
   pitest_dest: target/pit-reports

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -41,6 +41,6 @@ jobs:
         attempt_delay: 5000
         with: |        
           branch: gh-pages # The branch the action should deploy to.
-          folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
+          folder: target/reports/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -76,7 +76,7 @@ jobs:
   
     - name: Build javadoc
       run: |
-         mkdir -p target/site/apidocs
+         mkdir -p target/reports/apidocs
          mvn -DskipTests javadoc:javadoc
  
     - name: Deploy 🚀    
@@ -88,7 +88,7 @@ jobs:
         attempt_delay: 5000
         with: |        
           branch: gh-pages # The branch the action should deploy to.
-          folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
+          folder: target/reports/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 
   


### PR DESCRIPTION
In this PR, I update the workflows that involve the Javadocs to reference their new location under `/target/reports/apidocs` rather than their previous location under `/target/site/apidocs`.