### PR TITLE
Bumping the Node Version to the Latest LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 RUN java -version
 RUN curl --version
 
-ENV NODE_VERSION=20.17.0
+ENV NODE_VERSION=22.14.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ after completing your own.
 
 # Versions
 * Java: 21
-* node: 20.17.0
+* node: 22.14.0
 See [docs/versions.md](docs/versions.md) for more information on upgrading versions.
 
 # Brief overview of starter code 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,7 +58,7 @@
         "webpack": "^5.93.0"
       },
       "engines": {
-        "node": "=v20.17.0"
+        "node": "=v22.14.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "=v20.17.0"
+    "node": "=v22.14.0"
   },
   "dependencies": {
     "@jest/core": "^29.7.0",

--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@
                   <goal>install-node-and-npm</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v20.17.0</nodeVersion>
+                  <nodeVersion>v22.14.0</nodeVersion>
                 </configuration>
               </execution>
               <execution>
@@ -501,7 +501,7 @@
                   <goal>install-node-and-npm</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v20.17.0</nodeVersion>
+                  <nodeVersion>v22.14.0</nodeVersion>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
In this PR, I bump the Node version to the latest LTS. It runs correctly locally, and is deployed to https://team02-postgres.dokku-00.cs.ucsb.edu

All tests pass and mutations are killed. Closes #4 