### PR TITLE
Migration File Cleanup

### DIFF
--- a/src/main/resources/db/migration/changes/UCSBDates.json
+++ b/src/main/resources/db/migration/changes/UCSBDates.json
@@ -27,7 +27,7 @@
                       "autoIncrement": true,
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "CONSTRAINT_5"
+                        "primaryKeyName": "UCSBDATES_PK"
                       },
                       "name": "ID",
                       "type": "BIGINT"

--- a/src/main/resources/db/migration/changes/UCSBDiningCommons.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommons.json
@@ -25,7 +25,7 @@
                     "column": {
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "CONSTRAINT_2"
+                        "primaryKeyName": "DININGCOMMONS_PK"
                       },
                       "name": "CODE",
                       "type": "VARCHAR(255)"

--- a/src/main/resources/db/migration/changes/Users.json
+++ b/src/main/resources/db/migration/changes/Users.json
@@ -26,7 +26,7 @@
                     "autoIncrement": true,
                     "constraints": {
                       "primaryKey": true,
-                      "primaryKeyName": "CONSTRAINT_4"
+                      "primaryKeyName": "USERS_PK"
                     },
                     "name": "ID",
                     "type": "BIGINT"


### PR DESCRIPTION
In this PR, I updated the primary key name for each database table to be in line with the scheme of `DATABASE_TABLE_NAME_PK` rather than `CONSTRAINT_NUMBER`. 

Sister PR to [team01](https://github.com/ucsb-cs156-s25/STARTER-team01/pulls/24)