### PR TITLE
Update storybook version in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,7 @@
     "nyc": "^17.0.0",
     "prettier": "^3.3.3",
     "prop-types": "^15.8.1",
-    "storybook": "^8.2.9",
+    "storybook": "8.2.9",
     "typescript-eslint": "^8.2.0",
     "webpack": "^5.93.0"
   },


### PR DESCRIPTION
Storybook has been causing an error with version 8.4.2 (see here: https://github.com/storybookjs/storybook/issues/29559).

This PR pins the version to 8.2.9 which works with the current codebase.