### PR TITLE
Adding a Workflow for Status Check Enforcement

### DIFF
--- a/.github/workflows/60-workflow-enforcement.yml
+++ b/.github/workflows/60-workflow-enforcement.yml
@@ -4,42 +4,8 @@ on:
   pull_request:
 
 jobs:
-  waitForWorkflows:
-    name: Wait for workflows
+  wait-for-workflows:
     runs-on: ubuntu-latest
-    if: always()
+    timeout-minutes: 40
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Wait for workflows
-        id: wait
-        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@main
-        with:
-          max-timeout: "900"
-          polling-interval: "30"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DEBUG: "true"
-
-  afterWait:
-    name: after-wait
-    needs: [waitForWorkflows]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check needs results
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-            results=$(gh pr checks $PR_NUMBER --json state --jq '.[] | select(.state == "FAILURE")')
-            echo "$results"
-            if [ -z "$results" ]; then
-            exit 0;
-            else
-            exit 1;
-            fi
+      - uses: int128/wait-for-workflows-action@v1

--- a/.github/workflows/60-workflow-enforcement.yml
+++ b/.github/workflows/60-workflow-enforcement.yml
@@ -1,0 +1,45 @@
+name: 60 - Workflow Status Check Enforcement
+
+on:
+  pull_request:
+
+jobs:
+  waitForWorkflows:
+    name: Wait for workflows
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Wait for workflows
+        id: wait
+        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@main
+        with:
+          max-timeout: "900"
+          polling-interval: "30"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          DEBUG: "true"
+
+  afterWait:
+    name: after-wait
+    needs: [waitForWorkflows]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check needs results
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+            results=$(gh pr checks $PR_NUMBER --json state --jq '.[] | select(.state == "FAILURE")')
+            echo "$results"
+            if [ -z "$results" ]; then
+            exit 0;
+            else
+            exit 1;
+            fi


### PR DESCRIPTION
In this PR, I add a workflow that waits for every other status check to complete, then if they all pass, it returns green. Otherwise, it returns red. In the future, the check time may need to be increased to >15 minutes depending on the length of the average stryker mutation test.

Example PR fail visible here: https://github.com/ucsb-cs156-s25/STARTER-team02/pull/76

Because branch protection rules and Rulesets do not allow \* operators, this is a way to add one static check as the one that needs to be checked, as it will enforce the rest of the workflows.